### PR TITLE
[Feat] 축제 리스트 및 스크롤 함수 생성

### DIFF
--- a/public/dummy.ts
+++ b/public/dummy.ts
@@ -17,6 +17,16 @@ export type RoomInfo = {
   imgUrl: string;
 };
 
+export type Festival = {
+  id: number;
+  img: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  city: string;
+  url: string;
+};
+
 export const dummyRooms: RoomInfo[] = [
   {
     id: 1,
@@ -99,3 +109,69 @@ export const dummyRegions = [
     { region: '충청북도', detailRegions: ['청주', '충주', '제천', '음성', '진천', '단양'] },
     { region: '경기도', detailRegions: ['수원', '성남', '용인', '고양', '부천', '안양'] }
   ];
+
+export const dummyFestivals: Festival[] = [
+  {
+    id:1,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:2,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:3,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:4,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:5,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:6,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:7,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+];

--- a/public/dummy.ts
+++ b/public/dummy.ts
@@ -174,4 +174,67 @@ export const dummyFestivals: Festival[] = [
     city:"충청남도 아산시",
     url:"https://github.com/hanaro7team1/frontend"
   },
+  {
+    id:8,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:9,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:10,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:11,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:12,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:13,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
+  {
+    id:14,
+    img:"/images/dummy_image.png",
+    title: "신정호 별빛축제",
+    startDate:"2025.09.01",
+    endDate:"2025.09.10",
+    city:"충청남도 아산시",
+    url:"https://github.com/hanaro7team1/frontend"
+  },
 ];

--- a/src/app/festivals/page.tsx
+++ b/src/app/festivals/page.tsx
@@ -55,11 +55,11 @@ export default function FestivalsPage() {
     <Header title='지역 축제' bgColor='green'/>
 
     <div className='p-4'>
-      <div className='relative rounded-[10px] flex justify-end 
+      <div className='relative rounded-[10px] flex justify-center 
                     border border-green-edc bg-green-2f1
                     items-center'>  
           <Image src="/images/Img_Festival.svg" alt='쇼핑' width={107} height={107} className='absolute left-0' />
-          <Txt size={24} weight='medium' className='text-center mr-15'>즐거운 지역축제<br />함께 시도해요!</Txt>
+          <Txt size={24} weight='medium' className='text-center ml-15'>즐거운 지역축제<br />함께 시도해요!</Txt>
       </div>
     </div>
 

--- a/src/app/festivals/page.tsx
+++ b/src/app/festivals/page.tsx
@@ -34,7 +34,7 @@ export default function FestivalsPage() {
 
   useEffect(() => {
     void loadData();
-  }, []);
+  }, [loadData]);
 
   useEffect(() => {
     const el = sentinelRef.current;
@@ -63,7 +63,7 @@ export default function FestivalsPage() {
       </div>
     </div>
 
-    <div className='flex flex-col p-6 gap-8'>
+    <div className='flex flex-col p-5 gap-8'>
       {events.map(f => (
           <ListBox key = {f.id} {...f} />
       ))}

--- a/src/app/festivals/page.tsx
+++ b/src/app/festivals/page.tsx
@@ -1,10 +1,75 @@
+'use client'
+
+import { Txt } from '@/components/atoms';
 import { BottomTabNav, Header } from '@/components/common';
+import ListBox from '@/components/domain/festivals/ListBox';
+import Image from 'next/image';
+import { dummyFestivals } from '../../../public/dummy';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const PAGE_SIZE = 4;
 
 export default function FestivalsPage() {
-  return (
-    <div>
-      <Header title='지역 축제' />
-      <BottomTabNav />
+  type Festival = typeof dummyFestivals[number];
+
+  const [events, setEvents] = useState<Festival[]>([]);
+  const [hasNext, setHasNext] = useState(true);
+  const [page, setPage] = useState(0);
+  const [load, setLoad] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const loadData = useCallback(() => {
+    if(load || !hasNext) return;
+    setLoad(true);
+
+    const start = page * PAGE_SIZE;
+    const end = page + PAGE_SIZE;
+    const chunk = dummyFestivals.slice(start, end);
+
+    setEvents(prev => [...prev, ...chunk]);
+    setHasNext(end < dummyFestivals.length);
+    setPage(prev => prev + 1);
+    setLoad(false);
+  }, [page, load, hasNext]);
+
+  useEffect(() => {
+    void loadData();
+  }, []);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if(!el) return;
+
+    const io = new IntersectionObserver(([entry]) => {
+      if(entry.isIntersecting) loadData();
+    }, {rootMargin: '100px'});
+
+    io.observe(el);
+    return () => io.disconnect();
+  }, [loadData]);
+
+  return <>
+    <Header title='지역 축제' bgColor='green'/>
+
+    <div className='p-4'>
+      <div className='relative rounded-[10px] flex justify-end 
+                    border border-green-edc bg-green-2f1
+                    items-center'>  
+          <Image src="/images/Img_Festival.svg" alt='쇼핑' width={107} height={107} className='absolute left-0' />
+          <Txt size={24} weight='medium' className='text-center mr-15'>즐거운 지역축제<br />함께 시도해요!</Txt>
+      </div>
     </div>
-  );
+
+    <div className='flex flex-col p-6 gap-4'>
+      {dummyFestivals.map(f => (
+          <ListBox key = {f.id} {...f} />
+      ))}
+    </div>
+
+    <div ref={sentinelRef} className='flex items-center justify-center text-gray-6d6'>
+      {load ? '불러오는중...' : hasNext ? '스크롤하여 더보기' : ''}
+    </div>
+
+    <BottomTabNav />
+  </>;
 }

--- a/src/app/festivals/page.tsx
+++ b/src/app/festivals/page.tsx
@@ -23,11 +23,11 @@ export default function FestivalsPage() {
     setLoad(true);
 
     const start = page * PAGE_SIZE;
-    const end = page + PAGE_SIZE;
+    const end = start + PAGE_SIZE;  
     const chunk = dummyFestivals.slice(start, end);
 
     setEvents(prev => [...prev, ...chunk]);
-    setHasNext(end < dummyFestivals.length);
+    setHasNext(dummyFestivals[end] !== undefined);
     setPage(prev => prev + 1);
     setLoad(false);
   }, [page, load, hasNext]);
@@ -41,8 +41,11 @@ export default function FestivalsPage() {
     if(!el) return;
 
     const io = new IntersectionObserver(([entry]) => {
-      if(entry.isIntersecting) loadData();
-    }, {rootMargin: '100px'});
+      if(entry.isIntersecting) {
+        loadData();
+      }
+    }, {root: null, 
+      rootMargin: '150px'});
 
     io.observe(el);
     return () => io.disconnect();
@@ -61,13 +64,13 @@ export default function FestivalsPage() {
     </div>
 
     <div className='flex flex-col p-6 gap-8'>
-      {dummyFestivals.map(f => (
+      {events.map(f => (
           <ListBox key = {f.id} {...f} />
       ))}
     </div>
 
     <div ref={sentinelRef} className='flex items-center justify-center text-gray-6d6'>
-      {load ? '불러오는중...' : hasNext ? '스크롤하여 더보기' : ''}
+      {load ? '불러오는중...' : hasNext ? '스크롤하여 더보기' : '마지막 페이지 입니다'}
     </div>
 
     <BottomTabNav />

--- a/src/app/festivals/page.tsx
+++ b/src/app/festivals/page.tsx
@@ -60,7 +60,7 @@ export default function FestivalsPage() {
       </div>
     </div>
 
-    <div className='flex flex-col p-6 gap-4'>
+    <div className='flex flex-col p-6 gap-8'>
       {dummyFestivals.map(f => (
           <ListBox key = {f.id} {...f} />
       ))}

--- a/src/components/domain/festivals/ListBox.tsx
+++ b/src/components/domain/festivals/ListBox.tsx
@@ -5,15 +5,15 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 
 type Props = {
+    id: number;
     img: string;
     title: string;
     startDate: string;
     endDate: string;
     city: string;
-    url: string;
 }
 
-export default function ListBox({img, title, startDate, endDate, city, url}:Props) {
+export default function ListBox({id, img, title, startDate, endDate, city}:Props) {
     const router = useRouter();
 
     return <>
@@ -25,7 +25,7 @@ export default function ListBox({img, title, startDate, endDate, city, url}:Prop
                 <Txt>{title}</Txt>
                 <Txt size={15}>{city}</Txt>
                 <Txt size={18}>{startDate} ~ {endDate}</Txt>
-                <Button title="상세보기" color="gray" className="h-[35px] mt-3" onClick={() => router.push(`${url}`)}/>
+                <Button title="상세보기" color="gray" className="h-[35px] mt-3" onClick={() => router.push(`/festivals/${id}`)}/>
             </div>
         </div>
     </>;

--- a/src/components/domain/festivals/ListBox.tsx
+++ b/src/components/domain/festivals/ListBox.tsx
@@ -17,15 +17,15 @@ export default function ListBox({img, title, startDate, endDate, city, url}:Prop
     const router = useRouter();
 
     return <>
-        <div className="flex gap-3 items-center">
+        <div className="flex gap-2 items-center">
             <div className="relative w-[154px] h-[154px] shrink-0 overflow-hidden rounded-[8px]">
                 <Image src={img} alt="축제" fill sizes="154px" className="object-cover"/>
             </div>
             <div className="flex flex-col gap-1">
                 <Txt>{title}</Txt>
-                <Txt size={18}>{startDate} ~ {endDate}</Txt>
+                <Txt size={15}>{startDate} ~ {endDate}</Txt>
                 <Txt size={15}>{city}</Txt>
-                <Button title="상세보기" color="gray" className="h-[35px]" onClick={() => router.push(`${url}`)}/>
+                <Button title="상세보기" color="gray" className="h-[35px] mt-3" onClick={() => router.push(`${url}`)}/>
             </div>
         </div>
     </>;

--- a/src/components/domain/festivals/ListBox.tsx
+++ b/src/components/domain/festivals/ListBox.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { Button, Txt } from "@/components/atoms";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+
+type Props = {
+    img: string;
+    title: string;
+    startDate: string;
+    endDate: string;
+    city: string;
+    url: string;
+}
+
+export default function ListBox({img, title, startDate, endDate, city, url}:Props) {
+    const router = useRouter();
+
+    return <>
+        <div className="flex gap-2">
+            <Image src={img} alt="축제" width={150} height={150} className="rounded-[8px] shrink-0"/>
+            <div className="flex flex-col">
+                <Txt>{title}</Txt>
+                <Txt>{startDate} ~ {endDate}</Txt>
+                <Txt>{city}</Txt>
+                <Button title="상세보기" color="gray" className="h-[35px]" onClick={() => router.push(`${url}`)}/>
+            </div>
+        </div>
+    </>;
+}

--- a/src/components/domain/festivals/ListBox.tsx
+++ b/src/components/domain/festivals/ListBox.tsx
@@ -17,12 +17,14 @@ export default function ListBox({img, title, startDate, endDate, city, url}:Prop
     const router = useRouter();
 
     return <>
-        <div className="flex gap-2">
-            <Image src={img} alt="축제" width={150} height={150} className="rounded-[8px] shrink-0"/>
-            <div className="flex flex-col">
+        <div className="flex gap-3 items-center">
+            <div className="relative w-[154px] h-[154px] shrink-0 overflow-hidden rounded-[8px]">
+                <Image src={img} alt="축제" fill sizes="154px" className="object-cover"/>
+            </div>
+            <div className="flex flex-col gap-1">
                 <Txt>{title}</Txt>
-                <Txt>{startDate} ~ {endDate}</Txt>
-                <Txt>{city}</Txt>
+                <Txt size={18}>{startDate} ~ {endDate}</Txt>
+                <Txt size={15}>{city}</Txt>
                 <Button title="상세보기" color="gray" className="h-[35px]" onClick={() => router.push(`${url}`)}/>
             </div>
         </div>

--- a/src/components/domain/festivals/ListBox.tsx
+++ b/src/components/domain/festivals/ListBox.tsx
@@ -17,14 +17,14 @@ export default function ListBox({img, title, startDate, endDate, city, url}:Prop
     const router = useRouter();
 
     return <>
-        <div className="flex gap-2 items-center">
+        <div className="flex gap-3 items-center">
             <div className="relative w-[154px] h-[154px] shrink-0 overflow-hidden rounded-[8px]">
-                <Image src={img} alt="축제" fill sizes="154px" className="object-cover"/>
+                <Image src={img} alt={title} fill className="object-cover"/>
             </div>
             <div className="flex flex-col gap-1">
                 <Txt>{title}</Txt>
-                <Txt size={15}>{startDate} ~ {endDate}</Txt>
                 <Txt size={15}>{city}</Txt>
+                <Txt size={18}>{startDate} ~ {endDate}</Txt>
                 <Button title="상세보기" color="gray" className="h-[35px] mt-3" onClick={() => router.push(`${url}`)}/>
             </div>
         </div>


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

## 📋 작업 사항

<!-- 작업 내용을 간략히 설명해주세요 -->
브랜치 관리 실수로 기존에 생성한 브랜치를 삭제해, 다시 올립니다

-스크롤 함수
축제 페이지 기본 구현 및 무한 스크롤 함수를 생성했습니다.
스크롤함수는 page.tsx의21 ~ 49 라인이며, 
백엔드에서 slice, hasNext함수로 리스트 페이지 생성을 한것을 프로트에서도 활용할 수 있게 하는 전제로 생성했습니다.
타 리스트를 보여주는 페이지에도 사용한다면, 세부 페이지 생성하면서 컴포넌트로 분리시키겠습니다.

-페이지 사항
세부 페이지가 없다는 전제로 만들어, 클릭시 바로 축제페이지로 이동하는 방식으로 만들었습니다.
추후 세부 페이지를 만들면 id를 통해 해당 상세 페이지로 이동하게 변경하겠습니다.

<br>

## 📸 구현 결과
<img width="393" height="643" alt="image" src="https://github.com/user-attachments/assets/772ab2d8-cff2-41c3-b746-3816bdd2d497" />

<img width="396" height="586" alt="image" src="https://github.com/user-attachments/assets/3b1f3b16-70a9-4e3c-9df9-d74c0106ba4e" />

<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

<br>

## 💬 기타

<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->
개선사항이 있으면 알려주시면 감사하겠습니다.
브랜치 삑사리 안나게 주의하겠습니다.

<br>
<!-- ⚠️ 잠깐 !!!! -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
