### PR TITLE
[Feat] 사랑방 예약 확정 시 시골 관리자에게 알림 모달 퍼블리싱

### DIFF
--- a/public/dummy.ts
+++ b/public/dummy.ts
@@ -85,7 +85,7 @@ export const dummyReservationDetail = {
   stayAddress: '경상북도 안동시 임하면 천등산길 124-16',
   guestName: '윤서연',
   schedule: '25.09.09 (화) - 25.09.13 (토)',
-  peopleCount: '2명',
+  peopleCount: '2',
   doWork: '희망 안 함',
   guestTel: '010-1234-5678',
   hostName: '김갑순',

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,9 +1,11 @@
 import Image from 'next/image';
 import { Txt } from '@/components/atoms';
 import { Bankbook, MenuTabs, ReservationStats } from '@/components/domain/admin';
+import { ReservationModal } from '@/components/domain/home';
+import { ReservationStatus } from '@/enums/reservation';
 
 export default function HomePage() {
-  // TODO: 실제 API 연동 → getVillageAccount(), getReservationStats()
+  // TODO: 실제 API 연동
   const user = {
     name: '가람마을',
   };
@@ -18,6 +20,14 @@ export default function HomePage() {
     booked: 12,
     staying: 2,
     completed: 32,
+  };
+
+  const payload = {
+    id: 1,
+    confirmedDate: '25.09.09 (화) - 25.09.13 (토)',
+    hostName: '김갑순',
+    roomName: '가람마을 사랑방 3호',
+    status: ReservationStatus.RESERVED,
   };
 
   const { name } = user;
@@ -45,6 +55,7 @@ export default function HomePage() {
 
       <footer className='mt-9 px-4'>
         <MenuTabs />
+        <ReservationModal payload={payload} />
       </footer>
     </div>
   );

--- a/src/components/domain/home/ModalInfo.tsx
+++ b/src/components/domain/home/ModalInfo.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { LucideProps } from 'lucide-react';
+import { ForwardRefExoticComponent } from 'react';
+import { Txt } from '@/components/atoms';
+
+type Props = {
+  icon: ForwardRefExoticComponent<LucideProps>;
+  label: string;
+  value: string;
+};
+
+export default function ModalInfo({ icon: Icon, label, value }: Props) {
+  return (
+    <div className='flex flex-col items-start gap-2'>
+      <div className='flex items-center gap-2'>
+        <Icon className='text-gray-070 h-5 w-5 flex-shrink-0' />
+        <Txt size={16} className='text-gray-070' align='center'>
+          {label}
+        </Txt>
+      </div>
+      <Txt size={18} weight='medium'>
+        {value}
+      </Txt>
+    </div>
+  );
+}

--- a/src/components/domain/home/ReservationModal.tsx
+++ b/src/components/domain/home/ReservationModal.tsx
@@ -2,20 +2,14 @@
 
 import { CalendarCheck, HomeIcon, User } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
-import { Button, Txt } from '@/components/atoms';
+import { useEffect, useState } from 'react';
+import { Txt } from '@/components/atoms';
 import Modal from '@/components/common/Modal';
+import { ReservationPayload } from '@/types/reservation';
 import ModalInfo from './ModalInfo';
 
-type ReservationPayload = {
-  id: number;
-  confirmedDate: string;
-  hostName: string;
-  roomName: string;
-};
-
 export default function ReservationModal({ payload }: { payload: ReservationPayload }) {
-  const { id, confirmedDate, hostName, roomName } = payload;
+  const { id, confirmedDate, hostName, roomName, status } = payload;
   const [open, setOpen] = useState(false);
 
   const reservationInfo = [
@@ -25,10 +19,15 @@ export default function ReservationModal({ payload }: { payload: ReservationPayl
   ];
   const router = useRouter();
 
+  // '예약 확정' 상태가 되면 시골 관리자에게 모달 보여주기
+  useEffect(() => {
+    if (status === 'RESERVED') {
+      setOpen(true);
+    }
+  }, [status]);
+
   return (
     <>
-      <Button title='예약 알림 보기' onClick={() => setOpen(true)} />
-
       {open && (
         <Modal
           leftBtnText='닫기'

--- a/src/components/domain/home/ReservationModal.tsx
+++ b/src/components/domain/home/ReservationModal.tsx
@@ -11,20 +11,26 @@ import ModalInfo from './ModalInfo';
 export default function ReservationModal({ payload }: { payload: ReservationPayload }) {
   const { id, confirmedDate, hostName, roomName, status } = payload;
   const [open, setOpen] = useState(false);
+  const router = useRouter();
 
   const reservationInfo = [
     { label: '예약된 사랑방 이름', icon: HomeIcon, value: roomName },
     { label: '예약된 일정', icon: CalendarCheck, value: confirmedDate },
     { label: '사랑방 주인 이름', icon: User, value: hostName },
   ];
-  const router = useRouter();
 
-  // '예약 확정' 상태가 되면 시골 관리자에게 모달 보여주기
+  // 예약 확정 상태이고, 사용자가 아직 확인하지 않은 경우에만 모달 오픈
   useEffect(() => {
-    if (status === 'RESERVED') {
+    const seen = localStorage.getItem(`reservation_modal_${id}_seen`);
+    if (status === 'RESERVED' && !seen) {
       setOpen(true);
     }
-  }, [status]);
+  }, [status, id]);
+
+  const handleClose = () => {
+    localStorage.setItem(`reservation_modal_${id}_seen`, 'true'); // 모달 확인 처리 저장
+    setOpen(false);
+  };
 
   return (
     <>
@@ -32,9 +38,10 @@ export default function ReservationModal({ payload }: { payload: ReservationPayl
         <Modal
           leftBtnText='닫기'
           rightBtnText='자세히 보기'
-          onClickLeftBtn={() => setOpen(false)}
+          onClickLeftBtn={handleClose}
           onClickRightBtn={() => {
-            router.push(`/reservations/${id}`); // 예약 상세 페이지로 이동
+            localStorage.setItem(`reservation_modal_${id}_seen`, 'true'); // 모달 확인 처리 저장
+            router.push(`/reservations/${id}`);
             setOpen(false);
           }}
           isPink={true}

--- a/src/components/domain/home/ReservationModal.tsx
+++ b/src/components/domain/home/ReservationModal.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { CalendarCheck, HomeIcon, User } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { Button, Txt } from '@/components/atoms';
+import Modal from '@/components/common/Modal';
+import ModalInfo from './ModalInfo';
+
+type ReservationPayload = {
+  id: number;
+  confirmedDate: string;
+  hostName: string;
+  roomName: string;
+};
+
+export default function ReservationModal({ payload }: { payload: ReservationPayload }) {
+  const { id, confirmedDate, hostName, roomName } = payload;
+  const [open, setOpen] = useState(false);
+
+  const reservationInfo = [
+    { label: '예약된 사랑방 이름', icon: HomeIcon, value: roomName },
+    { label: '예약된 일정', icon: CalendarCheck, value: confirmedDate },
+    { label: '사랑방 주인 이름', icon: User, value: hostName },
+  ];
+  const router = useRouter();
+
+  return (
+    <>
+      <Button title='예약 알림 보기' onClick={() => setOpen(true)} />
+
+      {open && (
+        <Modal
+          leftBtnText='닫기'
+          rightBtnText='자세히 보기'
+          onClickLeftBtn={() => setOpen(false)}
+          onClickRightBtn={() => {
+            router.push(`/reservations/${id}`); // 예약 상세 페이지로 이동
+            setOpen(false);
+          }}
+          isPink={true}
+        >
+          <div className='flex flex-col items-center'>
+            <Txt size={24} weight='bold' align='center' className='mb-2'>
+              예약 확정 알림
+            </Txt>
+            <Txt className='mb-4' align='center'>
+              사랑방 예약이 확정되었습니다.
+              <br /> 아래 내용을 확인해 주세요.
+            </Txt>
+
+            <div className='bg-gray-7f9 flex flex-col gap-5 overflow-hidden rounded-md px-5 py-6 text-left'>
+              {reservationInfo.map(({ label, icon, value }) => (
+                <ModalInfo key={label} icon={icon} label={label} value={value} />
+              ))}
+            </div>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/components/domain/home/index.ts
+++ b/src/components/domain/home/index.ts
@@ -1,3 +1,5 @@
 export { default as UpcommingStayCard } from './UpcommingStayCard';
 export { default as ReservationBtn } from './ReservationButton';
 export { default as LoanCard } from './LoanCard';
+export { default as ReservationModal } from './ReservationModal';
+export { default as ModalInfo } from './ModalInfo';

--- a/src/components/domain/reservations/InfoRow.tsx
+++ b/src/components/domain/reservations/InfoRow.tsx
@@ -19,7 +19,7 @@ export default function InfoRow({ icon: Icon, label, value }: Props) {
       </div>
       <div className='flex'>
         {label === '면적' && <Txt>약&nbsp;</Txt>}
-        <Txt size={value.length > 14 ? 16 : 20}>{value}</Txt>
+        <Txt size={value.length > 14 ? 18 : 20}>{value}</Txt>
         {label === '이름' && <Txt className='text-gray-070'>&nbsp;님</Txt>}
         {label === '면적' && <Txt>평</Txt>}
         {label.endsWith('인원') && <Txt>명</Txt>}

--- a/src/components/domain/reservations/StayInfoCard.tsx
+++ b/src/components/domain/reservations/StayInfoCard.tsx
@@ -24,16 +24,16 @@ export default function StayInfoCard({ data, isAdmin = false }: Props) {
       </div>
 
       <div className='flex flex-1 flex-col justify-between gap-2'>
-        <div className='flex flex-col p-1'>
+        <div className='flex flex-col gap-2 p-1'>
           <Txt size={22}>{title}</Txt>
-          <Txt size={18} className='text-gray-070'>
+          <Txt size={18} className='text-gray-070 break-keep whitespace-normal'>
             {address}
           </Txt>
         </div>
         {!isAdmin && (
           <Link
             href={`/stays/${stayId}`}
-            className='bg-orange-85a flex w-full justify-center rounded-[10px] py-1'
+            className='bg-orange-85a flex w-full justify-center rounded-[10px] py-1.5'
           >
             <Txt className='text-white'>숙소 보러 가기</Txt>
           </Link>

--- a/src/enums/reservation.ts
+++ b/src/enums/reservation.ts
@@ -1,0 +1,5 @@
+export enum ReservationStatus {
+  PENDING = 'PENDING', // 예약하기
+  RESERVED = 'RESERVED', // 예약 확정
+  CANCELLED = 'CANCELLED', // 예약 취소
+}

--- a/src/types/reservation.ts
+++ b/src/types/reservation.ts
@@ -1,0 +1,9 @@
+import { ReservationStatus } from '@/enums/reservation';
+
+export type ReservationPayload = {
+  id: number;
+  confirmedDate: string;
+  hostName: string;
+  roomName: string;
+  status: ReservationStatus;
+};


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

## 📋 작업 사항

예약 확정 상태(`RESERVED`)가 되면 시골 관리자 홈 페이지에서 예약 확정 안내 모달을 보여주도록 구현했습니다.
알림 모달에는 예약된 사랑방 이름, 예약된 일정, 사랑방 주인 이름이 표시됩니다.

- ReservationStatus enum 추가
  - `PENDING`, `RESERVED`, `CANCELLED` 상태 정의
  - 예약 상태 관리의 일관성 확보

- ReservationModal 컴포넌트 구현
  - payload로 예약 정보 전달 (id, confirmedDate, hostName, roomName, status)
  - status === 'RESERVED'인 경우 자동으로 모달 오픈
  - 모달 내부에서 예약 정보(ModalInfo) 렌더링
  - “자세히 보기” 클릭 시 예약 상세 페이지 `/reservations/{id}`로 이동
  - 사용자가 모달을 확인하고 '닫기' 버튼 누르면 이후에는 모달 다시 뜨지 않도록 구현 (localStorage 활용)

<br>

## 📸 구현 결과

<img width="310" height="683" alt="스크린샷 2025-09-03 오후 2 18 02" src="https://github.com/user-attachments/assets/bbbb1472-6751-422d-af26-9c3e8a0900c8" />

<br>

## 💬 기타

현재는 API가 없어서 모달을 자동으로 띄우는 기능만 WebSocket 없이 퍼블리싱 했습니다.
실제 서비스에서는 예약 확정 이벤트를 서버에서 실시간 푸시해야 하므로 WebSocket을 써서 구현할 예정입니다.

<br>
<!-- ⚠️ 잠깐 !!!! -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
