### PR TITLE
[Feat] 사랑방 수정 api 연결 완료

### DIFF
--- a/src/app/admin/stays/[id]/page.tsx
+++ b/src/app/admin/stays/[id]/page.tsx
@@ -1,7 +1,8 @@
+import { serverPrivateApi } from '@/lib/axios-server';
 import { Header } from '@/components/common';
 import { EditStay } from '@/components/domain/admin/edit';
 import { StayInfoCard } from '@/components/domain/reservations';
-import { stayDetail } from '../../../../../public/dummy';
+import { StayDetailResponseType } from '@/types/stays';
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -10,18 +11,19 @@ type Props = {
 export default async function AdminStayEditPage({ params }: Props) {
   const { id } = await params;
 
-  const { stayPicURL, stayId, stayName, stayAddress, capacity, area, description } = stayDetail;
+  const api = await serverPrivateApi();
+  const { data } = await api.get<StayDetailResponseType>(`/api/stays/${id}`);
+  const { title, address, capacity, areaSize, description, images, id: stayId } = data;
+
+  console.log('response image', images);
 
   return (
     <div className='flex flex-col gap-4'>
       <Header title='사랑방 정보 수정하기' />
 
       <main className='flex flex-col gap-10 px-5'>
-        <StayInfoCard
-          data={{ stayPicURL, stayId, title: stayName, address: stayAddress }}
-          isAdmin
-        />
-        <EditStay data={{ area, capacity, description }} />
+        <StayInfoCard data={{ stayPicURL: images[0], stayId, title, address }} isAdmin />
+        <EditStay data={{ areaSize, capacity, description, stayId }} />
       </main>
     </div>
   );

--- a/src/components/domain/admin/edit/EditStay.tsx
+++ b/src/components/domain/admin/edit/EditStay.tsx
@@ -1,25 +1,48 @@
 'use client';
 
 import { SquareRoundCorner, Users } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { privateApi } from '@/lib/axios-client';
 import { Input, ShadowBox, Txt } from '@/components/atoms';
-import { FixedBottomButton } from '@/components/common';
+import { FixedBottomButton, Modal } from '@/components/common';
 import { InfoRow } from '../../reservations';
 import { BottomSheetArea, BottomSheetCapacity } from '../../stays';
 
 type Props = {
   data: {
-    area: number;
+    areaSize: number;
     capacity: number;
     description: string;
+    stayId: number;
   };
 };
 
 export default function EditStay({ data }: Props) {
-  const { area, capacity, description } = data;
+  const router = useRouter();
+  const { areaSize, capacity, description, stayId } = data;
 
-  const [newArea, setNewArea] = useState([area]);
+  const [newArea, setNewArea] = useState([areaSize]);
   const [newCapacity, setNewCapacity] = useState(capacity);
+  const [newDescription, setNewDescription] = useState(description);
+
+  const [isOpen, setIsOpened] = useState(false);
+
+  const payload = {
+    capacity: newCapacity,
+    areaSize: newArea[0],
+    description: newDescription,
+  };
+
+  const submitHandler = async () => {
+    try {
+      await privateApi.patch(`api/admin/stays/${stayId}`, payload);
+      setIsOpened(true);
+    } catch (e) {
+      //TODO: 시간 남으면 토스트 처리...
+      alert(e);
+    }
+  };
 
   return (
     <>
@@ -45,6 +68,7 @@ export default function EditStay({ data }: Props) {
           placeholder='사랑방을 소개해주세요'
           tag='textarea'
           className='resize-none'
+          onChange={(e) => setNewDescription(e.target.value)}
         />
       </div>
 
@@ -52,9 +76,23 @@ export default function EditStay({ data }: Props) {
         leftBtnText='취소하기'
         onClickLeftBtn={() => alert('취소')}
         rightBtnText='수정 완료하기'
-        onClickRightBtn={() => alert('수정완료')}
+        onClickRightBtn={() => submitHandler()}
         isPink
       />
+      {isOpen && (
+        <Modal
+          rightBtnText={'확인'}
+          leftBtnText={'취소'}
+          onClickRightBtn={() => {
+            setIsOpened(false);
+            router.push(`/stays/${stayId}`);
+          }}
+          onClickLeftBtn={() => setIsOpened(false)}
+          isPink={true}
+        >
+          등록이 완료되었습니다
+        </Modal>
+      )}
     </>
   );
 }

--- a/src/types/stays.ts
+++ b/src/types/stays.ts
@@ -31,8 +31,7 @@ export type StayDetailResponseType = {
   description: string;
   isHomestay: boolean;
   isActiveMsg: string;
-
-  // images?: string[];
+  images: string[];
 };
 
 export type StayListItemResponse = {
@@ -43,6 +42,12 @@ export type StayListItemResponse = {
   stayResrvStatus: '예약 가능' | '예약 마감' | '예약 닫힘';
 };
 export type StayListResponse = Paged<StayListItemResponse>;
+
+export type StayPatchResponse = {
+  capacity: number;
+  areaSize: number;
+  description: string;
+};
 
 export type AdminStayListItemResponse = {
   hostName: string;


### PR DESCRIPTION
## 📋 작업 사항

- 수정 페이지에서 데이터 get으로 불러오게 연결
- description도 수정 가능하도록 변경
- 평수, 수용 인원 수, 설명 수정할 시 patch로 변경되도록 api 연결 완료

<br>

## 📸 구현 결과


<br>

## 💬 기타

- accessToken이 next.js가 생각보다 시간이 짧은지 가끔 Access Denied 되는데, 로그인 다시 하면 해결이 됩니다 

<img width="786" height="645" alt="image" src="https://github.com/user-attachments/assets/ed09ab19-4ea8-4ea4-b5cf-48e312316f8f" />

- [ ]  지금 ddl이 create 상태라서 이미지가 db에 없어서 오류가 날 수 있습니다 (이미지 기본값 넣을 수 있도록 곧 변경 예정)
