### PR TITLE
[Refactor] 사랑방 삭제 api 연결 & 삭제 결과 모달 추가

### DIFF
--- a/src/app/stays/[id]/page.tsx
+++ b/src/app/stays/[id]/page.tsx
@@ -25,7 +25,6 @@ export default async function StayDetailPage({ params, searchParams }: Props) {
     },
   });
 
-  console.log('schedule: ', searchParam.schedule);
   const { id, title, stayResrvStatus, address, capacity, areaSize, images, description } = data;
 
   const isAdmin = await getIsAdmin();

--- a/src/components/domain/stays/CountrysideActionBar.tsx
+++ b/src/components/domain/stays/CountrysideActionBar.tsx
@@ -2,7 +2,9 @@
 
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { privateApi } from '@/lib/axios-client';
 import { FixedBottomButton, Modal } from '@/components/common';
+import { StayDeleteResponse } from '@/types/stays';
 
 type Props = {
   id: number;
@@ -13,10 +15,51 @@ type Props = {
 export default function CountrysideActionBar({ id, onEdit, onDelete }: Props) {
   const router = useRouter();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isResultModalOpen, setIsResultModalOpen] = useState(false);
+
+  const [deleted, setDeleted] = useState<boolean | null>(null);
+  const [hasActiveReservations, setHasActiveReservations] = useState<boolean | null>(null);
+  const [deleteMsg, setDeleteMsg] = useState<string | null>(null);
 
   const handleOpenModal = () => setIsModalOpen(true);
   const handleCloseModal = () => setIsModalOpen(false);
+  const handleOpenResultModal = () => setIsResultModalOpen(true);
+  const handleCloseResultModal = () => setIsResultModalOpen(false);
 
+  const handleDelete = async () => {
+    try {
+      const { data } = await privateApi.delete<StayDeleteResponse>(`/api/admin/stays/${id}`);
+
+      let msg: string;
+      if (data.deleted === false) {
+        msg = '이미 삭제된 사랑방입니다.';
+      } else if (data.deleted === true && data.hasActiveReservations === true) {
+        msg = '방문 전 예약이 있습니다.\n[예약 관리하기]를 통해\n예약자에게 연락 바랍니다.';
+      } else {
+        msg = '삭제가 완료되었습니다.';
+      }
+
+      setDeleted(data.deleted);
+      setHasActiveReservations(data.hasActiveReservations);
+      setDeleteMsg(msg);
+    } catch {
+      setDeleted(null);
+      setHasActiveReservations(null);
+      setDeleteMsg('삭제 요청 중 오류가 발생했습니다.');
+    } finally {
+      handleCloseModal();
+      handleOpenResultModal();
+    }
+  };
+
+  const goList = () => {
+    handleCloseResultModal();
+    if (deleted === true && hasActiveReservations === true) {
+      router.push('/reservations');
+    } else {
+      router.push('/admin/stays');
+    }
+  };
   return (
     <>
       <FixedBottomButton
@@ -38,12 +81,21 @@ export default function CountrysideActionBar({ id, onEdit, onDelete }: Props) {
           leftBtnText='취소'
           rightBtnText='삭제하기'
           onClickLeftBtn={handleCloseModal}
-          onClickRightBtn={() => {
-            if (onDelete) onDelete();
-            handleCloseModal();
-          }}
+          onClickRightBtn={handleDelete}
         >
           사랑방을 삭제하시겠습니까?
+        </Modal>
+      )}
+
+      {/* 삭제 결과 모달 */}
+      {isResultModalOpen && (
+        <Modal
+          leftBtnText='닫기'
+          rightBtnText='확인'
+          onClickLeftBtn={handleCloseResultModal}
+          onClickRightBtn={goList}
+        >
+          <span className='whitespace-pre-line'>{deleteMsg}</span>
         </Modal>
       )}
     </>

--- a/src/types/stays.ts
+++ b/src/types/stays.ts
@@ -76,3 +76,8 @@ export type PreviewImageItem = {
   previewUrl: string;
 };
 export type PresignResp = { url: string; key: string };
+
+export type StayDeleteResponse = {
+  deleted: boolean;
+  hasActiveReservations: boolean;
+};


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

## 📋 작업 사항
사랑방 삭제 api 연결했습니다. 모달에서 '삭제하기' 클릭시 삭제 api 부르도록 했습니다. 삭제 api 결과를 위한 모달을 추가하였습니다.
- 방문 전 예약이 있으면 -> 결과 모달 '확인' -> 예약 목록으로
- 그 외 -> 결과 모달 '확인' -> 우리 동네 사랑방 목록으로
- 결과 모달 '닫기' -> 모달 닫히고 사랑방 상세 페이지에 그대로
<!-- 작업 내용을 간략히 설명해주세요 -->

<br>

## 📸 구현 결과
<img width="603" height="1348" alt="image" src="https://github.com/user-attachments/assets/26fbf1e9-9e4b-4f20-92b0-e51009496c1c" />
<img width="604" height="1336" alt="image" src="https://github.com/user-attachments/assets/a6d47590-1da0-4f32-b211-3c809e0b2047" />

<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

<br>

## 💬 기타

<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

<br>
<!-- ⚠️ 잠깐 !!!! -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
