### PR TITLE
[Design] 시골 관리자 홈 페이지와 사랑방 목록 페이지 UI 수정

### DIFF
--- a/src/app/admin/mypage/contact/page.tsx
+++ b/src/app/admin/mypage/contact/page.tsx
@@ -18,17 +18,21 @@ export default function AdminContactPage() {
   const { showToast } = useToast();
 
   useEffect(() => {
-    const fetchAdminInfo = async () => {
+    let cancelled = false;
+
+    (async () => {
       try {
         const data = await getAdminInfoClient();
-        setPhone(formatPhone(data.phone));
+        if (!cancelled) setPhone(formatPhone(data.phone));
       } catch {
         showToast('관리자 정보를 불러오는 데 실패했습니다.', 'error');
       }
-    };
+    })();
 
-    fetchAdminInfo();
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [showToast]);
 
   // 전화번호 변경 API 호출 함수
   const handleUpdatePhone = async () => {

--- a/src/app/admin/stays/page.tsx
+++ b/src/app/admin/stays/page.tsx
@@ -1,4 +1,5 @@
 import { Header } from '@/components/common';
+import { AddStayBtn } from '@/components/domain/admin';
 import { AdminRoomList, FilterRoomStatus } from '@/components/domain/stays';
 import { AdminStaysSearchParams } from '@/types/stays';
 
@@ -13,6 +14,7 @@ export default async function AdminStaysPage({ searchParams }: Props) {
     <>
       <Header title='우리 마을 사랑방' withoutBorder />
       <FilterRoomStatus searchParams={searchParam} />
+      <AddStayBtn />
       <AdminRoomList searchParams={searchParam} />
     </>
   );

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -27,7 +27,14 @@ export default function Header({
   className,
 }: Props) {
   const router = useRouter();
-  const handleBack = () => router.back();
+
+  const handleBack = () => {
+    if (window.location.pathname.includes('/admin/stays')) {
+      router.replace('/admin');
+    } else {
+      router.back();
+    }
+  };
 
   const isWhiteBg = bgColor === 'white';
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChevronLeft } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { Txt } from '../atoms';
 
@@ -28,8 +28,10 @@ export default function Header({
 }: Props) {
   const router = useRouter();
 
+  const pathname = usePathname();
+
   const handleBack = () => {
-    if (window.location.pathname.includes('/admin/stays')) {
+    if (pathname.startsWith('/admin/stays')) {
       router.replace('/admin');
     } else {
       router.back();

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChevronLeft } from 'lucide-react';
-import { usePathname, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { Txt } from '../atoms';
 
@@ -28,15 +28,7 @@ export default function Header({
 }: Props) {
   const router = useRouter();
 
-  const pathname = usePathname();
-
-  const handleBack = () => {
-    if (pathname.startsWith('/admin/stays')) {
-      router.replace('/admin');
-    } else {
-      router.back();
-    }
-  };
+  const handleBack = () => router.back();
 
   const isWhiteBg = bgColor === 'white';
 

--- a/src/components/domain/admin/AddStayButton.tsx
+++ b/src/components/domain/admin/AddStayButton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { Txt } from '@/components/atoms';
+
+export default function AddStayButton() {
+  const router = useRouter();
+
+  return (
+    <section className='px-4 pt-3'>
+      <button
+        className={'bg-pink-a76/10 flex w-full items-center gap-3 rounded-[10px] py-[21px] pl-5'}
+        onClick={() => router.push('/admin/stays/add')}
+      >
+        <Plus className='text-pink-a76 items-center' size={22} />
+        <Txt className='text-pink-a76' size={22} weight='bold'>
+          사랑방 등록하기
+        </Txt>
+      </button>
+    </section>
+  );
+}

--- a/src/components/domain/admin/AddStayButton.tsx
+++ b/src/components/domain/admin/AddStayButton.tsx
@@ -1,23 +1,19 @@
-'use client';
-
 import { Plus } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { Txt } from '@/components/atoms';
 
 export default function AddStayButton() {
-  const router = useRouter();
-
   return (
     <section className='px-4 pt-3'>
-      <button
-        className={'bg-pink-a76/10 flex w-full items-center gap-3 rounded-[10px] py-[21px] pl-5'}
-        onClick={() => router.push('/admin/stays/add')}
+      <Link
+        href='/admin/stays/add'
+        className='bg-pink-a76/10 flex w-full items-center gap-3 rounded-[10px] py-[21px] pl-5'
       >
-        <Plus className='text-pink-a76 items-center' size={22} />
+        <Plus className='text-pink-a76' size={22} />
         <Txt className='text-pink-a76' size={22} weight='bold'>
           사랑방 등록하기
         </Txt>
-      </button>
+      </Link>
     </section>
   );
 }

--- a/src/components/domain/admin/MenuTabs.tsx
+++ b/src/components/domain/admin/MenuTabs.tsx
@@ -1,32 +1,25 @@
-'use client';
-
 import { House, List, User } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { Txt } from '@/components/atoms';
 
 export default function MenuTabs() {
-  const router = useRouter();
-
   const commonClasses = 'flex flex-col justify-between rounded-[10px] p-6 text-left';
 
   return (
     <div className='flex flex-col gap-3'>
-      <button
+      <Link
+        href='/admin/stays'
         className='bg-pink-a76/70 flex h-24 w-full items-center justify-between rounded-[10px] p-6 text-white'
-        onClick={() => router.push('/admin/stays')}
       >
         <Txt className='text-white' weight='bold'>
           우리 마을 사랑방
           <br /> 관리하기
         </Txt>
         <House size={28} className='text-white' />
-      </button>
+      </Link>
 
       <div className='grid grid-cols-2 gap-3'>
-        <button
-          className={`${commonClasses} bg-pink-a76/10 h-36`}
-          onClick={() => router.push('/stays')}
-        >
+        <Link href='/stays' className={`${commonClasses} bg-pink-a76/10 h-36`}>
           <Txt className='text-pink-a76' weight='bold'>
             전체 사랑방 <br />
             구경하기
@@ -34,12 +27,9 @@ export default function MenuTabs() {
           <div className='flex items-end justify-end'>
             <List size={28} className='text-pink-a76' />
           </div>
-        </button>
+        </Link>
 
-        <button
-          className={`${commonClasses} bg-pink-a76/50 h-36 text-white`}
-          onClick={() => router.push('/admin/mypage')}
-        >
+        <Link href='/admin/mypage' className={`${commonClasses} bg-pink-a76/50 h-36 text-white`}>
           <Txt className='text-white' weight='bold'>
             내 정보 <br />
             수정하기
@@ -47,7 +37,7 @@ export default function MenuTabs() {
           <div className='flex items-end justify-end'>
             <User size={28} className='text-white' />
           </div>
-        </button>
+        </Link>
       </div>
     </div>
   );

--- a/src/components/domain/admin/MenuTabs.tsx
+++ b/src/components/domain/admin/MenuTabs.tsx
@@ -1,66 +1,54 @@
 'use client';
 
-import { List, Plus, Settings, User } from 'lucide-react';
+import { House, List, User } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Txt } from '@/components/atoms';
 
 export default function MenuTabs() {
   const router = useRouter();
 
-  const commonClasses = 'flex flex-col justify-between rounded-[10px] px-4 py-5 text-left h-36';
+  const commonClasses = 'flex flex-col justify-between rounded-[10px] p-6 text-left';
 
   return (
-    <div className='grid grid-cols-7 gap-3'>
+    <div className='flex flex-col gap-3'>
       <button
-        className={`${commonClasses} bg-pink-a76/70 col-span-4 text-white`}
+        className='bg-pink-a76/70 flex h-24 w-full items-center justify-between rounded-[10px] p-6 text-white'
         onClick={() => router.push('/admin/stays')}
       >
         <Txt className='text-white' weight='bold'>
-          우리 마을 사랑방 <br />
-          관리하기
+          우리 마을 사랑방
+          <br /> 관리하기
         </Txt>
-        <div className='flex justify-end'>
-          <Settings size={28} className='text-white' />
-        </div>
+        <House size={28} className='text-white' />
       </button>
 
-      <button
-        className={`${commonClasses} bg-pink-a76/10 col-span-3`}
-        onClick={() => router.push('/admin/stays/add')}
-      >
-        <Txt className='text-pink-a76' weight='bold'>
-          사랑방 <br />
-          추가하기
-        </Txt>
-        <div className='flex items-end justify-end'>
-          <Plus size={28} className='text-pink-a76' />
-        </div>
-      </button>
+      <div className='grid grid-cols-2 gap-3'>
+        <button
+          className={`${commonClasses} bg-pink-a76/10 h-36`}
+          onClick={() => router.push('/stays')}
+        >
+          <Txt className='text-pink-a76' weight='bold'>
+            전체 사랑방 <br />
+            구경하기
+          </Txt>
+          <div className='flex items-end justify-end'>
+            <List size={28} className='text-pink-a76' />
+          </div>
+        </button>
 
-      <button
-        className={`${commonClasses} bg-pink-a76/10 col-span-3`}
-        onClick={() => router.push('/stays')}
-      >
-        <Txt className='text-pink-a76' weight='bold'>
-          전체 사랑방 <br />
-          구경하기
-        </Txt>
-        <div className='flex items-end justify-end'>
-          <List size={28} className='text-pink-a76' />
-        </div>
-      </button>
-
-      <button
-        className={`${commonClasses} bg-pink-a76/50 col-span-4 text-white`}
-        onClick={() => router.push('/admin/mypage')}
-      >
-        <Txt className='text-white' weight='bold'>
-          내 정보 수정
-        </Txt>
-        <div className='flex items-end justify-end'>
-          <User size={28} className='text-white' />
-        </div>
-      </button>
+        <button
+          className={`${commonClasses} bg-pink-a76/50 h-36 text-white`}
+          onClick={() => router.push('/admin/mypage')}
+        >
+          <Txt className='text-white' weight='bold'>
+            내 정보 <br />
+            수정하기
+          </Txt>
+          <div className='flex items-end justify-end'>
+            <User size={28} className='text-white' />
+          </div>
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/domain/admin/add/wizard/WizardNav.tsx
+++ b/src/components/domain/admin/add/wizard/WizardNav.tsx
@@ -15,7 +15,7 @@ export default function WizardNav() {
   const router = useRouter();
 
   const prevStep = () =>
-    currentStep === FIRST_STEP_NUM ? router.push('/admin') : goToStep(currentStep - 1);
+    currentStep === FIRST_STEP_NUM ? router.push('/admin/stays') : goToStep(currentStep - 1);
 
   //다음 step으로 이동하기 전에 이벤트 실행
   const nextStep = async () => {

--- a/src/components/domain/admin/add/wizard/WizardNav.tsx
+++ b/src/components/domain/admin/add/wizard/WizardNav.tsx
@@ -15,7 +15,7 @@ export default function WizardNav() {
   const router = useRouter();
 
   const prevStep = () =>
-    currentStep === FIRST_STEP_NUM ? router.push('/admin/stays') : goToStep(currentStep - 1);
+    currentStep === FIRST_STEP_NUM ? router.back() : goToStep(currentStep - 1);
 
   //다음 step으로 이동하기 전에 이벤트 실행
   const nextStep = async () => {

--- a/src/components/domain/admin/index.ts
+++ b/src/components/domain/admin/index.ts
@@ -4,3 +4,4 @@ export { default as ReservationStatsContainer } from './ReservationStatsContaine
 export { default as MenuTabs } from './MenuTabs';
 export { default as ReservationListener } from './ReservationListener';
 export { default as ReservationModal } from './ReservationModal';
+export { default as AddStayBtn } from './AddStayButton';

--- a/src/components/domain/main/ReservationButton.tsx
+++ b/src/components/domain/main/ReservationButton.tsx
@@ -1,23 +1,17 @@
-'use client';
-
 import { List } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { Txt } from '@/components/atoms';
 
 export default function ReservationButton() {
-  const router = useRouter();
-
   return (
-    <button
-      className={
-        'bg-green-49d flex w-full items-center gap-3 rounded-[10px] py-[21px] pl-5'
-      }
-      onClick={() => router.push('/reservations')}
+    <Link
+      href='/reservations'
+      className='bg-green-49d flex w-full items-center gap-3 rounded-[10px] py-[21px] pl-5'
     >
-      <List className='items-center text-white' size={32} />
+      <List className='text-white' size={32} />
       <Txt className='text-white' size={22} weight='bold'>
         나의 예약 목록 보기
       </Txt>
-    </button>
+    </Link>
   );
 }

--- a/src/components/domain/stays/AdminRoomItem.tsx
+++ b/src/components/domain/stays/AdminRoomItem.tsx
@@ -23,7 +23,7 @@ export default function AdminRoomItem({ data }: Props) {
 
   return (
     <ShadowBox>
-      <div className='relative h-[140px] overflow-hidden'>
+      <div className='relative h-[140px] overflow-hidden' onClick={goToDetailPage}>
         <Image src={imageURL} alt={title} fill className='object-cover' />
       </div>
       <div className='space-y-4 p-3'>


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

## 📋 작업 사항

기존 시골 관리자 홈 페이지의 하단탭 버튼을 수정하였습니다.
사랑방 목록 페이지에서의 사랑방 등록하기 버튼으로 등록 단계를 진행합니다.

<br>

## 📸 구현 결과

<img width="308" height="684" alt="스크린샷 2025-09-07 오후 9 57 01" src="https://github.com/user-attachments/assets/4dc9f114-f008-467f-b182-62204fc560fe" />
<img width="309" height="686" alt="스크린샷 2025-09-07 오후 9 57 12" src="https://github.com/user-attachments/assets/e6e4d977-a3ce-40dc-a2de-c82228a4d763" />


<br>

## 💬 기타

뒤로가기 처리 알맞게 되었는지 확인해주세요!

<br>
<!-- ⚠️ 잠깐 !!!! -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
