### PR TITLE
[Fix] 매물 목록 페이지 사진 오류 수정

### DIFF
--- a/src/components/domain/realEstates/EstateItem.tsx
+++ b/src/components/domain/realEstates/EstateItem.tsx
@@ -8,14 +8,14 @@ type Props = {
 };
 
 export default function EstateItem({ data }: Props) {
-  const { id, tradeType, location, price, imageUrls } = data;
+  const { id, tradeType, location, price, imageUrl } = data;
 
   return (
     <ShadowBox>
       <Link href={`/real-estates/${id}`}>
         <div className='relative h-[140px] overflow-hidden'>
           <Image
-            src={imageUrls ? imageUrls[0] : '/images/sample1.png'}
+            src={imageUrl || '/images/sample1.png'}
             alt={location + tradeType + price}
             fill
             className='object-cover'

--- a/src/types/real-estates.ts
+++ b/src/types/real-estates.ts
@@ -25,6 +25,6 @@ export type EstatesListItemResponse = {
   location: string;
   price: string;
   tradeType: '매매' | '전세';
-  imageUrls: string;
+  imageUrl: string;
 };
 export type EstatesListResponse = Paged<EstatesListItemResponse>;


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

## 📋 작업 사항

매물 목록 페이지에서 사진 데이터가 안보이던 문제 해결했습니다. 백엔드에서 List<String>로 주던 값을 String으로 바꿈에 따라 필드명도 `imageUrl`로 변경하여 프론트엔드도 맞춰줬습니다.

<br>

## 📸 구현 결과

사진 데이터 있는 로컬로 확인했습니다.

<br>

## 💬 기타

추가 수정사항 있으면 알려주세요

<br>
<!-- ⚠️ 잠깐 !!!! -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
